### PR TITLE
Unobtrusive hand items patch

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -59,9 +59,10 @@ BUILD INSTRUCTIONS (For Linux -- windows will use gradlew.bat instead of ./gradl
 
 4. Create a 'libs' folder in the /rfp2/ directory.
 
-5. Populate the 'libs' folder by downloading the latest 12.2 versions of these:
+5. Populate the 'libs' folder by downloading the latest 1.12.2 versions of these:
         CosmeticArmorReworked-1.12.2-(version).jar
         Morph-1.12.2-(version).jar
+	Baubles-1.12-(version).jar
 
 6. Build
     ./gradlew build

--- a/src/main/java/com/rejahtavi/rfp2/RFP2Config.java
+++ b/src/main/java/com/rejahtavi/rfp2/RFP2Config.java
@@ -62,6 +62,10 @@ public class RFP2Config
         @Name("Enable Status Messages")
         public boolean enableStatusMessages = true;
         
+        @Comment({ "Prevents hand items from covering your screen.", "Default: false" })
+        @Name("Unobtrusive Hand Items")
+        public boolean enableUOHItems = false;
+        
         @Comment({ "How far behind the camera to put the first person player model", "Default: 0.35" })
         @Name("Player Model Offset")
         @RangeDouble(


### PR DESCRIPTION
I added a way to make hand items less obtrusive and weird.

Before:
![image](https://user-images.githubusercontent.com/46451269/105823560-ea867680-5f82-11eb-82f3-298d3c07f2f5.png)
After:
![image](https://user-images.githubusercontent.com/46451269/105823616-fd00b000-5f82-11eb-872c-c415ec55b5e2.png)
![image](https://user-images.githubusercontent.com/46451269/105824308-c9725580-5f83-11eb-8300-ebe2dd4fb3c5.png)
![image](https://user-images.githubusercontent.com/46451269/105824333-d1ca9080-5f83-11eb-9aa9-d3637ce3a766.png)
![image](https://user-images.githubusercontent.com/46451269/105823889-579a0c00-5f83-11eb-809f-43543ce28dbd.png)
![image](https://user-images.githubusercontent.com/46451269/105823919-5d8fed00-5f83-11eb-8297-e03994802a91.png)
![image](https://user-images.githubusercontent.com/46451269/105825079-c9bf2080-5f84-11eb-9f01-c75e910e9114.png)
![image](https://user-images.githubusercontent.com/46451269/105825086-ccba1100-5f84-11eb-833a-9e612603c7f2.png)